### PR TITLE
number column header should be overridden

### DIFF
--- a/lib/hirb/helpers/table.rb
+++ b/lib/hirb/helpers/table.rb
@@ -128,7 +128,7 @@ module Hirb
     @rows = set_rows(rows)
     @headers = set_headers
     if @options[:number]
-      @headers[:hirb_number] = "number"
+      @headers[:hirb_number] ||= "number"
       @fields.unshift :hirb_number
     end
     Helpers::Table.last_table = self

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -361,6 +361,19 @@ describe "Table" do
       table([['a','b'], ['c', 'd']], :number=>true).should == expected_table
     end
 
+    it "number option renders with header that can be overridden" do
+      expected_table = <<-TABLE.unindent
+      +----+---+---+
+      | SR | 0 | 1 |
+      +----+---+---+
+      | 1  | a | b |
+      | 2  | c | d |
+      +----+---+---+
+      2 rows in set
+      TABLE
+      table([['a','b'], ['c', 'd']], :number=>true, :headers => {:hirb_number => "SR"}).should == expected_table
+    end
+
     it "description option false renders" do
       expected_table = <<-TABLE.unindent
       +---+---+


### PR DESCRIPTION
At the moment the column header when :number => true is hardcoded. With this pull it would be possible to override it using the :headers option.
