### PR TITLE
markdown-style tables!

### DIFF
--- a/lib/hirb/helpers.rb
+++ b/lib/hirb/helpers.rb
@@ -13,6 +13,6 @@ module Hirb
 end
 
 %w{table object_table auto_table tree parent_child_tree vertical_table
-  unicode_table}.each do |e|
+  default_table markdown_table unicode_table}.each do |e|
   require "hirb/helpers/#{e}"
 end

--- a/lib/hirb/helpers/default_table.rb
+++ b/lib/hirb/helpers/default_table.rb
@@ -1,0 +1,36 @@
+# Produces a table like this:
+#     +----------------+----------+------+--------------+
+#     | name           | commands | gems | library_type |
+#     +----------------+----------+------+--------------+
+#     | core/object    | 6        |      | file         |
+#     | dir            | 7        |      | file         |
+#     | file           | 5        |      | file         |
+#     | readme         | 4        |      | file         |
+#     | system         | 4        |      | file         |
+#     | readmemd       | 1        |      | file         |
+#     | github         | 9        |      | file         |
+#     | reload_library | 1        |      | file         |
+#     | system_misc    | 11       |      | file         |
+#     | tree           | 4        |      | file         |
+#     | core/class     | 4        |      | file         |
+#     | core/module    | 3        |      | file         |
+#     | console        | 3        |      | file         |
+#     | syntax         | 4        |      | file         |
+#     | core           | 6        |      | module       |
+#     | web_core       | 5        |      | module       |
+#     +----------------+----------+------+--------------+
+#
+class Hirb::Helpers::DefaultTable < Hirb::Helpers::Table
+  CHARS = {
+    :top => {:left => '+', :center => '+', :right => '+', :horizontal => '-',
+      :vertical => {:outside => '|', :inside => '|'} },
+    :middle => {:left => '+', :center => '+', :right => '+', :horizontal => '-'},
+    :bottom => {:left => '+', :center => '+', :right => '+', :horizontal => '-',
+      :vertical => {:outside => '|', :inside => '|'} }
+  }
+
+  # Renders a table
+  def self.render(rows, options={})
+    new(rows, options).render
+  end
+end

--- a/lib/hirb/helpers/markdown_table.rb
+++ b/lib/hirb/helpers/markdown_table.rb
@@ -1,0 +1,43 @@
+# Produces a table like this:
+# 
+#    | name            |  commands  |  gems               |  library_type |
+#    |---------------- | ---------- | ------------------- | --------------|
+#    | core/object     |  6         |                     |  file         |
+#    | dir             |  7         |                     |  file         |
+#    | file            |  5         |                     |  file         |
+#    | readme          |  4         |                     |  file         |
+#    | system          |  4         |                     |  file         |
+#    | readmemd        |  1         |                     |  file         |
+#    | github          |  9         |                     |  file         |
+#    | reload_library  |  1         |                     |  file         |
+#    | system_misc     |  11        |                     |  file         |
+#    | tree            |  4         |                     |  file         |
+#    | core/class      |  4         |                     |  file         |
+#    | core/module     |  3         |                     |  file         |
+#    | console         |  3         |                     |  file         |
+#    | core            |  6         |                     |  module       |
+#    | web_core        |  5         |                     |  module       |
+#    | ansi            |  3         |  ansi,win32console  |  file         |
+#
+#    NOTE: This does not currently include column alignment:
+#    |  left   | center  | right |
+#    | :------ | :-----: | ----: |
+#
+#    NOTE: This does not actually output markdown (or HTML), but rather
+#    formats the table in a way which is compatible with markdown tables, and
+#    hence compatible with markdown to HTML table conversion.
+#
+class Hirb::Helpers::MarkdownTable < Hirb::Helpers::Table
+  CHARS = {
+    :top => {:left => '', :center => '', :right => '', :horizontal => '',
+      :vertical => {:outside => '|', :inside => ' | '} },
+    :middle => {:left => '|', :center => ' | ', :right => '|', :horizontal => '-'},
+    :bottom => {:left => '', :center => '', :right => '', :horizontal => '',
+      :vertical => {:outside => '|', :inside => ' | '} }
+  }
+
+  # Renders a markdown-compatible table
+  def self.render(rows, options={})
+    new(rows, options).render
+  end
+end

--- a/lib/hirb/helpers/table.rb
+++ b/lib/hirb/helpers/table.rb
@@ -63,14 +63,6 @@ module Hirb
   MIN_FIELD_LENGTH = 3
   class TooManyFieldsForWidthError < StandardError; end
 
-  CHARS = {
-    :top => {:left => '+', :center => '+', :right => '+', :horizontal => '-',
-      :vertical => {:outside => '|', :inside => '|'} },
-    :middle => {:left => '+', :center => '+', :right => '+', :horizontal => '-'},
-    :bottom => {:left => '+', :center => '+', :right => '+', :horizontal => '-',
-      :vertical => {:outside => '|', :inside => '|'} }
-  }
-
   class << self
     
     # Main method which returns a formatted table.
@@ -111,7 +103,8 @@ module Hirb
     def render(rows, options={})
       options[:vertical] ? Helpers::VerticalTable.render(rows, options) :
       options[:unicode]  ? Helpers::UnicodeTable.render(rows, options) :
-      new(rows, options).render
+      options[:markdown] ? Helpers::MarkdownTable.render(rows, options) :
+                           Helpers::DefaultTable.render(rows, options)
     rescue TooManyFieldsForWidthError
       $stderr.puts "", "** Hirb Warning: Too many fields for the current width. Configure your width " +
         "and/or fields to avoid this error. Defaulting to a vertical table. **"


### PR DESCRIPTION
- added markdown_table
- added both to helpers
- moved default chars into default_table.rb
# See [comments](https://github.com/technogeeky/hirb/commit/4c11db4e1df074005437c947945724b7e8b85c63#commitcomment-487866) for motivating examples.
