### PR TITLE
Add support for choosing * or *:bro with actions and 2D menus

### DIFF
--- a/lib/hirb/menu.rb
+++ b/lib/hirb/menu.rb
@@ -171,7 +171,11 @@ module Hirb
         @new_args << CHOSEN_ARG
         field = $3 ? unalias_field($3) : default_field ||
           raise(Error, "No default field/column found. Fields must be explicitly picked.")
-        [Util.choose_from_array(@output, word), field]
+        if return_cell_values?
+          [Util.choose_from_array(@output, word), field]
+        else
+          [[Util.choose_from_array(@output, word)], nil]
+        end
       elsif word[ALL_REGEXP]
         @new_args << CHOSEN_ARG
         $2 ? [ALL_ARG, unalias_field($2)] : ALL_ARG

--- a/test/menu_test.rb
+++ b/test/menu_test.rb
@@ -177,6 +177,11 @@ describe "Menu" do
       two_d_menu(:action=>true, :two_d=>nil, :invoke=>[[{:a=>1, :bro=>2}]])
     end
 
+    it "with 1d invokes on multiple choices" do
+      menu_input "p 1,2 1-2"
+      two_d_menu(:action=>true, :two_d=>nil, :invoke=>[[{:a => 1, :bro => 2}, {:a => 3, :bro => 4}, {:a => 1, :bro => 2}, {:a => 3, :bro => 4}]])
+    end
+
     it "with non-choice arguments invokes" do
       menu_input "p arg1 1"
       two_d_menu :action=>true, :invoke=>['arg1', [1]]


### PR DESCRIPTION
Hi,

I've been building out some boson tools into my project and noticed that I can select all choices in a basic menu, but not with action menus or 2D menus. This adds support for all choices in action menus `p *` and all rows with fields in 2D menus `p *:bar`.
