### PR TITLE
explicit require of test/unit (minitest)

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+require 'test/unit'
 require 'bacon'
 require 'bacon/bits'
 require 'mocha'


### PR DESCRIPTION
Fix error "Test::Unit or MiniTest must be loaded _before_ Mocha" 

see http://brettlischalk.com/posts/10-test-unit-or-minitest-must-be-loaded-before-mocha 
see http://gofreerange.com/mocha/docs/
