### PR TITLE
Support for Mongoid dynamic fields

### DIFF
--- a/lib/hirb/helpers/object_table.rb
+++ b/lib/hirb/helpers/object_table.rb
@@ -7,7 +7,7 @@ class Hirb::Helpers::ObjectTable < Hirb::Helpers::Table
     options[:fields] ||= [:to_s]
     options[:headers] ||= {:to_s=>'value'} if options[:fields] == [:to_s]
     item_hashes = options[:fields].empty? ? [] : Array(rows).inject([]) {|t,item|
-      t << options[:fields].inject({}) {|h,f| h[f] = item.__send__(f); h}
+      t << options[:fields].inject({}) {|h,f| h[f] = item.__send__(f) rescue item.__send__("[]",f); h}
     }
     super(item_hashes, options)
   end

--- a/lib/hirb/views/mongo_db.rb
+++ b/lib/hirb/views/mongo_db.rb
@@ -1,6 +1,8 @@
 module Hirb::Views::MongoDb #:nodoc:
   def mongoid__document_view(obj)
     fields = obj.class.fields.keys
+    dynamic_fields = obj.attributes.keys.reject {|field| fields.include? field}
+    fields |= dynamic_fields
     fields.delete('_id')
     fields.unshift('_id')
     {:fields=>fields}

--- a/test/views_test.rb
+++ b/test/views_test.rb
@@ -15,8 +15,9 @@ end
 describe "mongoid table" do
   it "only has one _id" do
     fields = {'_id' => 'x0f0x', 'name' => 'blah'}
-    mongoid_stub = stub(:class => stub(:fields => fields))
+    dynamic_fields = {'test' => 'footbar'}
+    mongoid_stub = stub(:class => stub(:fields => fields), :attributes => fields.merge(dynamic_fields))
     Helpers::AutoTable.mongoid__document_view(mongoid_stub).should ==
-      {:fields => fields.keys.sort}
+      {:fields => (fields.keys | dynamic_fields.keys).sort }
   end
 end


### PR DESCRIPTION
If the attribute is dynamic field, Mongoid not provide the getters and setters and enforce to method_missing call. In this case must use the other provided accessor methods: ([] and []=) or (read_attribute and write_attribute).

Please check pull request.
Thanks.
