### PR TITLE
Add mongo_table for support MongoDB's dynamic fields

### DIFF
--- a/lib/hirb/helpers.rb
+++ b/lib/hirb/helpers.rb
@@ -12,7 +12,7 @@ module Hirb
   end
 end
 
-%w{table object_table auto_table tree parent_child_tree vertical_table
+%w{table object_table mongo_table auto_table tree parent_child_tree vertical_table
   markdown_table unicode_table tab_table}.each do |e|
   require "hirb/helpers/#{e}"
 end

--- a/lib/hirb/helpers/auto_table.rb
+++ b/lib/hirb/helpers/auto_table.rb
@@ -2,8 +2,7 @@
 # providing default helper options via Hirb::DynamicView. Using these default options, this
 # helper supports views for the following modules/classes:
 # ActiveRecord::Base, CouchFoo::Base, CouchPotato::Persistence, CouchRest::ExtendedDocument,
-# DBI::Row, DataMapper::Resource, Friendly::Document, MongoMapper::Document, MongoMapper::EmbeddedDocument,
-# Mongoid::Document, Ripple::Document, Sequel::Model.
+# DBI::Row, DataMapper::Resource, Friendly::Document, Ripple::Document, Sequel::Model.
 class Hirb::Helpers::AutoTable < Hirb::Helpers::Table
   extend Hirb::DynamicView
 

--- a/lib/hirb/helpers/mongo_table.rb
+++ b/lib/hirb/helpers/mongo_table.rb
@@ -1,0 +1,16 @@
+# Creates a mongo table for support MongoDB's dynamic fields
+class Hirb::Helpers::MongoTable < Hirb::Helpers::Table
+  extend Hirb::DynamicView
+  # output are any ruby objects. Takes same options as Hirb::Helpers::Table.render except as noted below.
+  #
+  # ==== Options:
+  # [:fields] Methods of the object to represent as columns.
+  def self.render(output, options ={})
+    output = Array(output)
+    (defaults = dynamic_options(output[0])) && (options = defaults.merge(options))
+    item_hashes = options[:fields].empty? ? [] : Array(output).inject([]) {|t,item|
+      t << options[:fields].inject({}) {|h,f| h[f] = item.__send__(f) rescue item.__send__("read_attribute", f); h}
+    }
+    super(item_hashes, options)
+  end
+end

--- a/lib/hirb/views/mongo_db.rb
+++ b/lib/hirb/views/mongo_db.rb
@@ -1,6 +1,8 @@
 module Hirb::Views::MongoDb #:nodoc:
   def mongoid__document_view(obj)
     fields = obj.class.fields.keys
+    dynamic_fields = obj.attributes.keys.reject {|field| fields.include? field}
+    fields |= dynamic_fields
     fields.delete('_id')
     fields.unshift('_id')
     {:fields=>fields}
@@ -14,4 +16,4 @@ module Hirb::Views::MongoDb #:nodoc:
   alias_method :mongo_mapper__embedded_document_view, :mongo_mapper__document_view
 end
 
-Hirb::DynamicView.add Hirb::Views::MongoDb, :helper=>:auto_table
+Hirb::DynamicView.add Hirb::Views::MongoDb, :helper=>:mongo_table

--- a/test/mongo_table_test.rb
+++ b/test/mongo_table_test.rb
@@ -1,0 +1,36 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+describe "mongo table" do
+  def table(*args)
+    Helpers::MongoTable.render(*args)
+  end
+
+  before_all {
+    @pets = [stub(:name=>'rufus', :age=>7, :to_s=>'rufus'), stub(:name=>'alf', :age=>101, :to_s=>'alf')]
+  }
+  it "renders" do
+    expected_table = <<-TABLE.unindent
+    +-------+-----+
+    | name  | age |
+    +-------+-----+
+    | rufus | 7   |
+    | alf   | 101 |
+    +-------+-----+
+    2 rows in set
+    TABLE
+    table(@pets, :fields=>[:name, :age]).should == expected_table
+  end
+
+  it "with empty fields" do
+    expected_table = <<-TABLE.unindent
+    0 rows in set
+    TABLE
+    table(@pets, :fields => []).should == expected_table
+  end
+
+  it "doesn't raise error for objects that don't have :send defined" do
+    object = Object.new
+    class<<object; self; end.send :undef_method, :send
+    should.not.raise(NoMethodError) { table([object], :fields=>[:to_s]) }
+  end
+end

--- a/test/views_test.rb
+++ b/test/views_test.rb
@@ -15,8 +15,9 @@ end
 describe "mongoid table" do
   it "only has one _id" do
     fields = {'_id' => 'x0f0x', 'name' => 'blah'}
-    mongoid_stub = stub(:class => stub(:fields => fields))
-    Helpers::AutoTable.mongoid__document_view(mongoid_stub).should ==
-      {:fields => fields.keys.sort}
+    dynamic_fields = {'test' => 'footbar'}
+    mongoid_stub = stub(:class => stub(:fields => fields), :attributes => fields.merge(dynamic_fields))
+    Helpers::MongoTable.mongoid__document_view(mongoid_stub).should ==
+      {:fields => (fields.keys | dynamic_fields.keys).sort }
   end
 end


### PR DESCRIPTION
I follow up your suggest, and rework  is done.
Add mongo_table for support MongoDB's dynamic fields.

Please recheck pull again.
Thanks.
