### PR TITLE
Fix Hirb breaking on AR tables with no id column

### DIFF
--- a/lib/hirb/views/rails.rb
+++ b/lib/hirb/views/rails.rb
@@ -6,8 +6,8 @@ module Hirb::Views::Rails #:nodoc:
   def get_active_record_fields(obj)
     fields = obj.class.column_names.map {|e| e.to_sym }
     # if query used select
-    if obj.attributes.keys.sort != obj.class.column_names.sort
-      selected_columns = obj.attributes.keys
+    if obj.attributes.keys.compact.sort != obj.class.column_names.sort
+      selected_columns = obj.attributes.keys.compact
       sorted_columns = obj.class.column_names.dup.delete_if {|e| !selected_columns.include?(e) }
       sorted_columns += (selected_columns - sorted_columns)
       fields = sorted_columns.map {|e| e.to_sym}


### PR DESCRIPTION
Hirb kills a puppy every time you give it an ActiveRecord::Base table with no id column. I've heard that when a puppy dies it cries out 'comparison of String with nil failed'! This patch will save many puppies by compacting an object's attribute keys before comparing it with the object's class's column_names.
