### PR TITLE
Remove warnings

### DIFF
--- a/lib/hirb.rb
+++ b/lib/hirb.rb
@@ -55,6 +55,7 @@ module Hirb
 
     # Array of config files which are merged sequentially to produce config.
     # Defaults to config/hirb.yml and ~/.hirb_yml
+    undef :config_files
     def config_files
       @config_files ||= default_config_files
     end
@@ -69,6 +70,7 @@ module Hirb
       File.exists?(file) ? YAML::load_file(file) : {}
     end
 
+    undef :config
     def config(reload=false)
       if (@config.nil? || reload)
         @config = config_files.inject({}) {|acc,e|

--- a/lib/hirb/formatter.rb
+++ b/lib/hirb/formatter.rb
@@ -29,7 +29,7 @@ module Hirb
     # [*:options*] Options to pass the helper method or class.
     # [*:ancestor*] Boolean which when true causes subclasses of the output class to inherit its config. This doesn't effect the current
     #               output class. Defaults to false. This is used by ActiveRecord classes.
-    # 
+    #
     #   Examples:
     #     {'WWW::Delicious::Element'=>{:class=>'Hirb::Helpers::ObjectTable', :ancestor=>true, :options=>{:max_width=>180}}}
     #     {'Date'=>{:class=>:auto_table, :ancestor=>true}}
@@ -101,10 +101,10 @@ module Hirb
     def build_klass_config(output_class)
       output_ancestors = output_class.ancestors.map {|e| e.to_s}.reverse
       output_ancestors.pop
-      hash = output_ancestors.inject({}) {|h, klass|
-        add_klass_config_if_true(h, klass) {|c,klass| c[klass] && c[klass][:ancestor] }
+      hash = output_ancestors.inject({}) {|h, ancestor_klass|
+        add_klass_config_if_true(h, ancestor_klass) {|c, klass| c[klass] && c[klass][:ancestor] }
       }
-      add_klass_config_if_true(hash, output_class.to_s) {|c,klass| c[klass] }
+      add_klass_config_if_true(hash, output_class.to_s) {|c, klass| c[klass] }
     end
 
     def add_klass_config_if_true(hash, klass)

--- a/lib/hirb/helpers/table.rb
+++ b/lib/hirb/helpers/table.rb
@@ -302,6 +302,7 @@ class Helpers::Table
     max_fields.each {|k,max| @field_lengths[k] = max if @field_lengths[k].to_i > max }
   end
 
+  undef :max_fields
   def max_fields
     @max_fields ||= (@options[:max_fields] ||= {}).each {|k,v|
       @options[:max_fields][k] = (actual_width * v.to_f.abs).floor if v.to_f.abs < 1
@@ -312,6 +313,7 @@ class Helpers::Table
     @actual_width ||= self.width - (@fields.size * BORDER_LENGTH + 1)
   end
 
+  undef :width
   def width
     @width ||= @options[:max_width] || View.width
   end

--- a/lib/hirb/helpers/table/resizer.rb
+++ b/lib/hirb/helpers/table/resizer.rb
@@ -48,7 +48,7 @@ class Hirb::Helpers::Table
 
       # set all fields the same if relative doesn't work
       unless new_lengths.values.all? {|e| e > MIN_FIELD_LENGTH} && (sum(new_lengths.values) <= @width)
-        new_lengths = @field_lengths.inject({}) {|t,(k,v)| t[k] = @width / @field_size; t }
+        new_lengths = @field_lengths.inject({}) {|t,(k,_v)| t[k] = @width / @field_size; t }
       end
       @field_lengths.each {|k,v| @field_lengths[k] = new_lengths[k] }
     end

--- a/lib/hirb/menu.rb
+++ b/lib/hirb/menu.rb
@@ -89,7 +89,7 @@ module Hirb
     def choose_from_menu
       return unasked_choice if @output.size == 1 && !@options[:ask]
 
-      if (helper_class = Util.any_const_get(@options[:helper_class]))
+      if (Util.any_const_get(@options[:helper_class]))
         View.render_output(@output, :class=>@options[:helper_class], :options=>@options.merge(:number=>true))
       else
         @output.each_with_index {|e,i| puts "#{i+1}: #{e}" }

--- a/lib/hirb/util.rb
+++ b/lib/hirb/util.rb
@@ -13,7 +13,7 @@ module Hirb
         }
         klass
       rescue
-         nil
+        nil
       end
     end
 

--- a/lib/hirb/view.rb
+++ b/lib/hirb/view.rb
@@ -22,7 +22,7 @@ module Hirb
   #   >> {:a=>1, :b=>{:c=>3}}
   #   ---
   #   :a : 1
-  #   :b : 
+  #   :b :
   #     :c : 3
   #   => true
   #
@@ -115,9 +115,9 @@ module Hirb
         config[:width], config[:height] = determine_terminal_size(width, height)
         pager.resize(config[:width], config[:height])
       end
-      
+
       # This is the main method of this class. When view is enabled, this method searches for a formatter it can use for the output and if
-      # successful renders it using render_method(). The options this method takes are helper config hashes as described in 
+      # successful renders it using render_method(). The options this method takes are helper config hashes as described in
       # Hirb::Formatter.format_output(). Returns true if successful and false if no formatting is done or if not enabled.
       def view_output(output, options={})
         enabled? && config[:formatter] && render_output(output, options)
@@ -127,7 +127,7 @@ module Hirb
           false
         else
           index = (obj = e.backtrace.find {|f| f =~ /^\(eval\)/}) ? e.backtrace.index(obj) : e.backtrace.length
-          $stderr.puts "Hirb Error: #{e.message}", e.backtrace.slice(0,index).map {|e| "    " + e }
+          $stderr.puts "Hirb Error: #{e.message}", e.backtrace.slice(0,index).map {|_e| "    " + _e }
           true
         end
       end
@@ -140,6 +140,7 @@ module Hirb
       # A lambda or proc which handles the final formatted object.
       # Although this pages/puts the object by default, it could be set to do other things
       # i.e. write the formatted object to a file.
+      undef :render_method
       def render_method
         @render_method ||= default_render_method
       end
@@ -148,7 +149,7 @@ module Hirb
       def reset_render_method
         @render_method = default_render_method
       end
-      
+
       # Current console width
       def width
         config && config[:width] ? config[:width] : DEFAULT_WIDTH
@@ -253,10 +254,11 @@ module Hirb
 
       def config_loaded?; !!@config; end
 
+      undef :config
       def config
         @config
       end
-      
+
       def default_render_method
         lambda {|output| page_output(output) || puts(output) }
       end


### PR DESCRIPTION
```
/Users/trsw/github/hirb/lib/hirb/formatter.rb:105: warning: shadowing outer local variable - klass
/Users/trsw/github/hirb/lib/hirb/helpers/table/resizer.rb:51: warning: assigned but unused variable - v
/Users/trsw/github/hirb/lib/hirb/helpers/table.rb:305: warning: method redefined; discarding old max_fields
/Users/trsw/github/hirb/lib/hirb/helpers/table.rb:315: warning: method redefined; discarding old width
/Users/trsw/github/hirb/lib/hirb/view.rb:130: warning: shadowing outer local variable - e
/Users/trsw/github/hirb/lib/hirb/view.rb:143: warning: method redefined; discarding old render_method
/Users/trsw/github/hirb/lib/hirb/view.rb:256: warning: method redefined; discarding old config
/Users/trsw/github/hirb/lib/hirb/menu.rb:92: warning: assigned but unused variable - helper_class
/Users/trsw/github/hirb/lib/hirb.rb:58: warning: method redefined; discarding old config_files
/Users/trsw/github/hirb/lib/hirb.rb:72: warning: method redefined; discarding old config
```