### PR TITLE
Rescue NameError in formatter

### DIFF
--- a/lib/hirb/formatter.rb
+++ b/lib/hirb/formatter.rb
@@ -67,12 +67,15 @@ module Hirb
         call_output_method(options[:output_method], output) ) : output
       args = [output]
       args << options[:options] if options[:options] && !options[:options].empty?
-      if options[:method]
-        send(options[:method],*args)
-      elsif options[:class] && (helper_class = Helpers.helper_class(options[:class]))
-        helper_class.render(*args, &block)
-      elsif options[:output_method]
-        output
+      begin
+        if options[:method]
+          send(options[:method],*args)
+        elsif options[:class] && (helper_class = Helpers.helper_class(options[:class]))
+          helper_class.render(*args, &block)
+        elsif options[:output_method]
+          output
+        end
+      rescue NameError
       end
     end
 


### PR DESCRIPTION
So when Hirb tries pretty-print my lists, which are very often not intended to be tables (but happen to contain an AR object) it consistently breaks without recourse. It would be nicer to rescue in the render method than to swallow the whole block - but I'm not sure there is a very neat way to do that, since each formatter defines it's own renderer. 
