### PR TITLE
Add ability to accept omit argument for Ruby IRB

### DIFF
--- a/lib/hirb/view.rb
+++ b/lib/hirb/view.rb
@@ -183,7 +183,7 @@ module Hirb
           @output_method = true
           ::IRB::Irb.class_eval do
             alias_method :non_hirb_view_output, :output_value
-            def output_value #:nodoc:
+            def output_value(omit = false) #:nodoc:
               Hirb::View.view_or_page_output(@context.last_value) || non_hirb_view_output
             end
           end

--- a/test/view_test.rb
+++ b/test/view_test.rb
@@ -39,6 +39,13 @@ describe "View" do
       ::IRB::Irb.new(context_stub).output_value
     end
 
+    it "output_value accept omit argument from IRB" do
+      View.expects(:render_output).once
+      Hirb.enable
+      context_stub = stub(:last_value=>'')
+      ::IRB::Irb.new(context_stub).output_value(true)
+    end
+
     it "is enabled?" do
       Hirb.enable
       View.enabled?.should == true


### PR DESCRIPTION
When calling a setter this makes IRB it passed an argument that wants to truncate or omit some of the info. This is ideal for IRB, but HIRB throws an exception

https://github.com/ruby/irb/blob/457502a7468399ba3a176e5769c63a49c0e69e95/lib/irb.rb#L586

```shell
> value = true
/Users/brandit/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/hirb-0.7.3/lib/hirb/view.rb:186:in `output_value': wrong number of arguments (given 1, expected 0) (ArgumentError)
```